### PR TITLE
Scintilla Integration:

### DIFF
--- a/vs2019scintilla/win32/ScintillaWin.cxx
+++ b/vs2019scintilla/win32/ScintillaWin.cxx
@@ -3457,7 +3457,7 @@ LRESULT PASCAL ScintillaWin::SWndProc(
 			} catch (...) {
 			}
 			::SetWindowLong(hWnd, 0, 0);
-			int result = ::DefWindowProc(hWnd, iMessage, wParam, lParam);
+			LRESULT result = ::DefWindowProc(hWnd, iMessage, wParam, lParam);
 			SciHwnds_RmvHwndRef(hWnd);
 			return result;
 		} else {

--- a/vs2019scintilla/win32/ScintillaWin.cxx
+++ b/vs2019scintilla/win32/ScintillaWin.cxx
@@ -3453,12 +3453,13 @@ LRESULT PASCAL ScintillaWin::SWndProc(
 		if (iMessage == WM_NCDESTROY) {
 			try {
 				sci->Finalise();
-				SciHwnds_RmvHwndRef(hWnd);
 				delete sci;
 			} catch (...) {
 			}
 			::SetWindowLong(hWnd, 0, 0);
-			return ::DefWindowProc(hWnd, iMessage, wParam, lParam);
+			int result = ::DefWindowProc(hWnd, iMessage, wParam, lParam);
+			SciHwnds_RmvHwndRef(hWnd);
+			return result;
 		} else {
 			return sci->WndProc(iMessage, wParam, lParam);
 		}


### PR DESCRIPTION
- Moved code which removes references to destroyed scintilla controls. This will now be the last thing done when destroying these controls. This is to ensure that surrounding code failure does NOT prevent the removal of destroyed references

- AMENDMENT:  Corrected return value datatype